### PR TITLE
feat: add operator upload warning msg

### DIFF
--- a/docs/en/install/create_service_mesh/create-servicemesh.md
+++ b/docs/en/install/create_service_mesh/create-servicemesh.md
@@ -29,6 +29,10 @@ For instructions on creating a multi-cluster service mesh, please refer to the M
   - `Alauda Build of Jaeger` Operator
   - `Alauda Build of OpenTelemetry` Operator
 
+  :::warning
+  When uploading the operators with `violet push`, do not add the `--target-catalog-source` parameter — use the default catalog source defined within the operator instead.
+  :::
+
 - Ensure that the cluster has deployed the Prometheus plugin or VictoriaMetrics plugin.
 
   **Note:** When VictoriaMetrics is a multi-cluster deployment architecture, `vmstorage` can be in a different cluster from the service mesh.

--- a/docs/en/install/create_service_mesh/index.mdx
+++ b/docs/en/install/create_service_mesh/index.mdx
@@ -21,4 +21,8 @@ Ensure the following operators are uploaded to the global cluster and the target
 - `Alauda Build of Jaeger` Operator
 - `Alauda Build of OpenTelemetry` Operator
 
+:::warning
+When uploading the operators with `violet push`, do not add the `--target-catalog-source` parameter — use the default catalog source defined within the operator instead.
+:::
+
 <Overview />

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -10,6 +10,21 @@ title: Upgrade
 
 Please visit [Alauda Service Mesh Essentials](./install/asm-essentials.mdx) for installation instructions.
 
+## Upload the Latest Operators to the Global and Target Clusters
+
+Upload the latest versions of the following operators to the **global** cluster and the target cluster (please do not install them manually):
+
+- `Alauda Service Mesh` Operator
+- `Flagger` Operator
+- `Alauda Build of Jaeger` Operator
+- `Alauda Build of OpenTelemetry` Operator
+
+For the upload procedure using the `violet` tool, please visit [Install Operator](./install/install-operator.mdx).
+
+:::warning
+When uploading the operators with `violet push`, do not add the `--target-catalog-source` parameter — use the default catalog source defined within the operator instead.
+:::
+
 ## Upgrade bussiness cluster components
 
 ### Before Upgrading \{#ref}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added important warnings and guidance for uploading operators during service mesh creation and system upgrades
  * Clarified command parameters and usage to prevent configuration errors when deploying required operators such as Alauda Service Mesh, Flagger, Jaeger, and OpenTelemetry
  * Updated installation prerequisites and upgrade documentation with essential operational best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->